### PR TITLE
Fix compilation on Windows

### DIFF
--- a/src/share_entry.rs
+++ b/src/share_entry.rs
@@ -6,7 +6,7 @@ use std::fs::{self, DirEntry};
 #[cfg(not(target_os = "windows"))]
 use std::os::unix::ffi::OsStrExt;
 #[cfg(target_os = "windows")]
-use OsStrExt;
+use crate::os_str_ext::OsStrExt;
 
 #[derive(Debug)]
 pub struct ShareEntry {


### PR DESCRIPTION
When compiling on Windows I get the following error:

```shell
error[E0432]: unresolved import `OsStrExt`
 --> src\share_entry.rs:9:5
  |
9 | use OsStrExt;
  |     ^^^^^^^^ no `OsStrExt` external crate

error[E0599]: no method named `as_bytes` found for type `std::ffi::OsString` in the current scope
  --> src\share_entry.rs:61:51
   |
61 |             percent_encoding::percent_encode(name.as_bytes(), percent_encoding::NON_ALPHANUMERIC)
   |                                                   ^^^^^^^^
   |
   = help: items from traits can only be used if the trait is in scope
   = note: the following traits are implemented but not in scope, perhaps add a `use` for one of them:
           candidate #1: `use crate::os_str_ext::OsStrExt;`
           candidate #2: `use regex::input::Input;`
           candidate #3: `use clap::osstringext::OsStrExt3;`

error: aborting due to 2 previous errors

Some errors have detailed explanations: E0432, E0599.
For more information about an error, try `rustc --explain E0432`.
error: Could not compile `rusty-share`.

To learn more, run the command again with --verbose.
```